### PR TITLE
feat(public_api): Expose MapComponent

### DIFF
--- a/src/app/lib/index.ts
+++ b/src/app/lib/index.ts
@@ -2,5 +2,6 @@ export * from './lib.module';
 
 // Expose MapService for ngx-mapbox-gl extensions
 export * from './map/map.service';
+export * from './map/map.component';
 
 export * from './map/map.types';


### PR DESCRIPTION
Expose MapComponent to the public_api. This is needed to satisfy the typescript compiler if you use as  # reference (e.g. let) on the map component in angular. Quick access to the map and starts the process for a multi-map scenario.