### PR TITLE
Export control component, for custom control directives

### DIFF
--- a/projects/ngx-mapbox-gl/src/public_api.ts
+++ b/projects/ngx-mapbox-gl/src/public_api.ts
@@ -4,6 +4,9 @@
 
 export * from './lib/ngx-mapbox-gl.module';
 
+// Expose control component to allow custom directives
+export * from './lib/control/control.component';
+
 // Expose MapService for ngx-mapbox-gl extensions
 export * from './lib/map/map.service';
 export * from './lib/map/map.component';


### PR DESCRIPTION
I want to be able to implement a custom directive for the mapbox-draw plugin. By exposing the  ControlComponent directive, I can create a directive in the same pattern that you use for the other control directives.

