### PR TITLE
Show default marker when element is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.2.1"></a>
+## [1.2.1](https://github.com/Wykks/ngx-mapbox-gl/compare/v1.2.0...v1.2.1) (2018-12-07)
+
+
+
 <a name="1.2.0"></a>
 # [1.2.0](https://github.com/Wykks/ngx-mapbox-gl/compare/v1.1.0...v1.2.0) (2018-05-21)
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
     "@types/lodash-es": "^4.17.0",
-    "@types/mapbox-gl": "^0.44.4",
+    "@types/mapbox-gl": "0.45.0",
     "@types/node": "~10.0.0",
     "@types/supercluster": "^3.0.2",
     "codelyzer": "~4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mapbox-gl",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Angular binding of mapbox-gl-js",
   "license": "MIT",
   "repository": {

--- a/src/app/lib/marker/marker.component.ts
+++ b/src/app/lib/marker/marker.component.ts
@@ -58,7 +58,7 @@ export class MarkerComponent implements OnChanges, OnDestroy, AfterViewInit, OnI
   }
 
   ngAfterViewInit() {
-    let options = {offset: this.offset, anchor: this.anchor, element: undefined};
+    const options = {offset: this.offset, anchor: this.anchor, element: undefined};
     if (this.content.nativeElement.childNodes.length > 0) {
       options.element = this.content.nativeElement;
     }

--- a/src/app/lib/marker/marker.component.ts
+++ b/src/app/lib/marker/marker.component.ts
@@ -58,7 +58,7 @@ export class MarkerComponent implements OnChanges, OnDestroy, AfterViewInit, OnI
   }
 
   ngAfterViewInit() {
-    let options = {offset: this.offset, anchor: this.anchor, element: null};
+    let options = {offset: this.offset, anchor: this.anchor, element: undefined};
     if (this.content.nativeElement.childNodes.length > 0) {
       options.element = this.content.nativeElement;
     }

--- a/src/app/lib/marker/marker.component.ts
+++ b/src/app/lib/marker/marker.component.ts
@@ -58,7 +58,11 @@ export class MarkerComponent implements OnChanges, OnDestroy, AfterViewInit, OnI
   }
 
   ngAfterViewInit() {
-    this.markerInstance = new Marker(<any>{ offset: this.offset, element: this.content.nativeElement, anchor: this.anchor });
+    let options = {offset: this.offset, anchor: this.anchor, element: null};
+    if (this.content.nativeElement.childNodes.length > 0) {
+      options.element = this.content.nativeElement;
+    }
+    this.markerInstance = new Marker(options);
     this.markerInstance.setLngLat(this.feature ? this.feature.geometry!.coordinates : this.lngLat!);
     this.MapService.mapCreated$.subscribe(() => {
       this.MapService.addMarker(this.markerInstance!);


### PR DESCRIPTION
In the v2 branch this was already fixed. If the mgl-marker HTML element is empty it should not be passed to the Marker constructor. 