### PR TITLE
fix(map): add an additional setStyle() call to prevent map loading issues...

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-mapbox-gl/src/lib/map/map.service.ts
@@ -510,6 +510,12 @@ export class MapService {
         }
       });
     this.mapInstance = new MapboxGl.Map(options);
+
+    const isIEorEdge = window && /msie\s|trident\/|edge\//i.test(window.navigator.userAgent);
+    if (isIEorEdge) {
+      this.mapInstance.setStyle(options.style!);
+    }
+
     const subChanges = this.zone.onMicrotaskEmpty
       .subscribe(() => this.applyChanges());
     if (this.MglResizeEventEmitter) {


### PR DESCRIPTION
…on IE11 (see https://github.com/mapbox/mapbox-gl-js/issues/4821#issuecomment-358998674).
Main issue is here: https://github.com/mapbox/mapbox-gl-js/issues/4623
Fixes https://github.com/Wykks/ngx-mapbox-gl/issues/66