### PR TITLE
Fix build error Closes #90

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/map/map.component.ts
+++ b/projects/ngx-mapbox-gl/src/lib/map/map.component.ts
@@ -31,7 +31,7 @@ declare global {
   namespace mapboxgl {
     export interface MapboxOptions {
       failIfMajorPerformanceCaveat?: boolean;
-      transformRequest?: Function;
+      transformRequest?: TransformRequestFunction;
       localIdeographFontFamily?: string;
       pitchWithRotate?: boolean;
     }


### PR DESCRIPTION
Was receiving the following error when trying to build an app that has TypeScript upgraded to >= 3.2.2

`ERROR in node_modules/ngx-mapbox-gl/lib/map/map.component.d.ts(9,13): error TS2717: Subsequent property declarations must have the same type.  Property
'transformRequest' must be of type 'TransformRequestFunction', but here has type 'Function'.`