### PR TITLE
Exposing error event data to directive output

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/map/map.service.ts
+++ b/projects/ngx-mapbox-gl/src/lib/map/map.service.ts
@@ -688,7 +688,7 @@ export class MapService {
       this.mapInstance.on('render', () => this.zone.run(() => events.render.emit()));
     }
     if (events.error.observers.length) {
-      this.mapInstance.on('error', () => this.zone.run(() => events.error.emit()));
+      this.mapInstance.on('error', (evt: MapboxGl.ErrorEvent) => this.zone.run(() => events.error.emit(evt)));
     }
     if (events.data.observers.length) {
       this.mapInstance.on('data', (evt: MapboxGl.EventData) => this.zone.run(() => events.data.emit(evt)));

--- a/projects/ngx-mapbox-gl/src/lib/map/map.types.ts
+++ b/projects/ngx-mapbox-gl/src/lib/map/map.types.ts
@@ -1,6 +1,6 @@
 // Can't use MapEvent interface from @types/mapbox because some event name are changed (eg zoomChange)
 import { EventEmitter } from '@angular/core';
-import { MapMouseEvent, MapTouchEvent, EventData, MapBoxZoomEvent, Map } from 'mapbox-gl';
+import { MapMouseEvent, MapTouchEvent, EventData, MapBoxZoomEvent, Map, ErrorEvent } from 'mapbox-gl';
 import { Results, Result } from '../control/geocoder-control.directive';
 
 export interface MapEvent {
@@ -43,7 +43,7 @@ export interface MapEvent {
   webGlContextRestored: EventEmitter<void>;
   load: EventEmitter<Map>;
   render: EventEmitter<void>;
-  error: EventEmitter<any>; // TODO Check type
+  error: EventEmitter<ErrorEvent>; // TODO Check type
   data: EventEmitter<EventData>;
   styleData: EventEmitter<EventData>;
   sourceData: EventEmitter<EventData>;


### PR DESCRIPTION
According to Mapbox API, the `error` event raises an message as its data. It's useful to log the actual error message in the application.