### PR TITLE
Add customAttribution Input to the Attribution Control

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/control/attribution-control.directive.ts
+++ b/projects/ngx-mapbox-gl/src/lib/control/attribution-control.directive.ts
@@ -9,6 +9,7 @@ import { ControlComponent } from './control.component';
 export class AttributionControlDirective implements OnInit {
   /* Init inputs */
   @Input() compact?: boolean;
+  @Input() customAttribution?: string | string[];
 
   constructor(
     private MapService: MapService,
@@ -20,9 +21,12 @@ export class AttributionControlDirective implements OnInit {
       if (this.ControlComponent.control) {
         throw new Error('Another control is already set for this control');
       }
-      const options: { compact?: boolean } = {};
+      const options: { compact?: boolean, customAttribution?: string | string[] } = {};
       if (this.compact !== undefined) {
         options.compact = this.compact;
+      }
+      if (this.customAttribution !== undefined) {
+        options.customAttribution = this.customAttribution;
       }
       this.ControlComponent.control = new AttributionControl(options);
       this.MapService.addControl(this.ControlComponent.control, this.ControlComponent.position);

--- a/projects/showcase/src/app/demo/demo.module.ts
+++ b/projects/showcase/src/app/demo/demo.module.ts
@@ -1,3 +1,4 @@
+import { CustomAttributionComponent } from './examples/custom-attribution.component';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
@@ -99,6 +100,7 @@ export const DEMO_ROUTES: Routes = [
       { path: 'mapbox-gl-geocoder', component: MapboxGlGeocoderComponent, data: { label: 'Add a geocoder', cat: Category.CONTROLS_AND_OVERLAYS } },
       { path: 'polygon-popup-on-click', component: PolygonPopupOnClickComponent, data: { label: 'Show polygon information on click', cat: Category.CONTROLS_AND_OVERLAYS } },
       { path: 'add-image-missing-generated', component: AddImageMissingGeneratedComponent, data: { label: 'Generate and add a missing icon to the map', cat: Category.STYLES } },
+      { path: 'custom-attribution', component: CustomAttributionComponent, data: { label: 'Add custom attributions', cat: Category.CONTROLS_AND_OVERLAYS } },
       { path: '**', redirectTo: 'display-map' }
     ]
   }
@@ -156,7 +158,8 @@ export const DEMO_ROUTES: Routes = [
     PolygonPopupOnClickComponent,
     NgxClusterHtmlComponent,
     ClusterPopupComponent,
-    AddImageMissingGeneratedComponent
+    AddImageMissingGeneratedComponent,
+    CustomAttributionComponent
   ]
 })
 export class DemoModule { }

--- a/projects/showcase/src/app/demo/examples/custom-attribution.component.ts
+++ b/projects/showcase/src/app/demo/examples/custom-attribution.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'showcase-demo',
+  template: `
+  <mgl-map
+    [style]="'mapbox://styles/mapbox/light-v9'"
+    [center]="[-77.04, 38.907]"
+    [zoom]="[11.15]"
+    [attributionControl]="false"
+  >
+    <mgl-control
+      mglAttribution
+      position="bottom-right"
+      [customAttribution]="[
+        '<a href=&quot;https://github.com/Wykks/ngx-mapbox-gl&quot; target=&quot;_blank&quot;>Maps made awesome in Angular</a>',
+        'Hello World'
+      ]"
+    ></mgl-control>
+  </mgl-map>
+  `,
+  styleUrls: ['./examples.css']
+})
+export class CustomAttributionComponent { }


### PR DESCRIPTION
* added: `customAttribution` Input to the `mglAttribution` Directive (in accordance to https://docs.mapbox.com/mapbox-gl-js/api/#attributioncontrol)
* added: demo for custom attributions based on the attribution-position example

Btw. thanks for the awesome mapbox-gl wrapper :)