### PR TITLE
Change property name for country option

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/control/geocoder-control.directive.ts
+++ b/projects/ngx-mapbox-gl/src/lib/control/geocoder-control.directive.ts
@@ -47,7 +47,7 @@ export interface Result extends GeoJSON.Feature<GeoJSON.Point> {
 })
 export class GeocoderControlDirective implements AfterContentInit, OnChanges, GeocoderEvent {
   /* Init inputs */
-  @Input() country?: string;
+  @Input() countries?: string;
   @Input() placeholder?: string;
   @Input() zoom?: number;
   @Input() bbox?: [number, number, number, number];
@@ -88,7 +88,7 @@ export class GeocoderControlDirective implements AfterContentInit, OnChanges, Ge
       }
       const options = {
         proximity: this.proximity,
-        country: this.country,
+        countries: this.countries,
         placeholder: this.placeholder,
         zoom: this.zoom,
         bbox: this.bbox,


### PR DESCRIPTION
According to the documentation the property should be called `countries`.

```
options.countries string? a comma separated list of country codes to limit results to specified country or countries.
```

https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md