### PR TITLE
Popup instance is now removed when a feature is used as input

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/popup/popup.component.ts
+++ b/projects/ngx-mapbox-gl/src/lib/popup/popup.component.ts
@@ -80,7 +80,7 @@ export class PopupComponent implements OnChanges, OnDestroy, AfterViewInit, OnIn
 
   ngOnDestroy() {
     if (this.popupInstance) {
-      if (this.lngLat) {
+      if (this.lngLat || this.feature) {
         this.MapService.removePopupFromMap(this.popupInstance);
       } else if (this.marker && this.marker.markerInstance) {
         this.MapService.removePopupFromMarker(this.marker.markerInstance);


### PR DESCRIPTION
This allows an `mgl-popup` component using a feature as input to be toggled on/off using `*ngIf`