### PR TITLE
fix(canvas-source): allow canvas source initialization from HTML element

### DIFF
--- a/projects/ngx-mapbox-gl/src/lib/source/canvas-source.component.ts
+++ b/projects/ngx-mapbox-gl/src/lib/source/canvas-source.component.ts
@@ -15,7 +15,7 @@ export class CanvasSourceComponent implements OnInit, OnDestroy, OnChanges, Canv
 
   /* Dynamic inputs */
   @Input() coordinates: number[][];
-  @Input() canvas: string;
+  @Input() canvas: string | HTMLCanvasElement;
   @Input() animate?: boolean;
 
   private sourceAdded = false;


### PR DESCRIPTION
Extends accepted input type of the `canvas` property to allow HTML element itself as well as element's id.
Mapbox API allows it for some time now: https://github.com/mapbox/mapbox-gl-js/blame/main/src/source/canvas_source.js#L28

Also, I would like to suggest to update no longer valid link to the [Mapbox GL style spec](https://www.mapbox.com/mapbox-gl-js/style-spec/#sources-canvas) for the `mgl-canvas-source` to this link https://docs.mapbox.com/mapbox-gl-js/api/sources/#canvassourceoptions.