### PR TITLE
fix: set baseApiUrl rather than assign config.API_URL which is now a getter

### DIFF
--- a/libs/ngx-mapbox-gl/src/lib/map/map.service.ts
+++ b/libs/ngx-mapbox-gl/src/lib/map/map.service.ts
@@ -109,7 +109,7 @@ export class MapService {
       //   options.accessToken || this.MAPBOX_API_KEY
       // );
       if (options.customMapboxApiUrl) {
-        this.assign(MapboxGl, 'config.API_URL', options.customMapboxApiUrl);
+        (MapboxGl.baseApiUrl as string) = options.customMapboxApiUrl;
       }
       this.createMap({
         ...(options.mapOptions as MapboxGl.MapboxOptions),


### PR DESCRIPTION
As mentioned in #390 setting the customMapboxApiUrl on the map component is throwing an error that it is unable to set property API_URL on config which is now a getter.

```
ngx-mapbox-gl.mjs:767 Uncaught TypeError: Cannot set property config of [object Module] which has only a getter
    at MapService.assign (ngx-mapbox-gl.mjs:767:1)
    at ngx-mapbox-gl.mjs:34:1
    at Object.next (Subscriber.js:123:1)
    at Subscriber._next (Subscriber.js:63:1)
    at Subscriber.next (Subscriber.js:34:1)
    at throwIfEmpty.js:10:1
    at OperatorSubscriber._this._next (OperatorSubscriber.js:11:1)
    at Subscriber.next (Subscriber.js:34:1)
    at take.js:12:1
    at OperatorSubscriber._this._next (OperatorSubscriber.js:11:1)
```

Mapbox provides a [baseApiUrl](https://docs.mapbox.com/mapbox-gl-js/api/properties/#baseapiurl) option that can be set on mapboxgl, example:
```
mapboxgl.baseApiUrl = 'https://api.mapbox.com';
```

How to test:
Set the `customMapboxApiUrl` input on the map component using the default value for Mapbox Cloud, "https://api.mapbox.com" (I am using this with an alternate Mapbox url, but the error will be shown if the config.API_URL is assign when `customMapboxApiUrl` is set.)