### PR TITLE
fix es-build angular 16 'Cannot assign to import "baseApiUrl"'

### DIFF
--- a/libs/ngx-mapbox-gl/src/lib/map/map.service.ts
+++ b/libs/ngx-mapbox-gl/src/lib/map/map.service.ts
@@ -6,7 +6,7 @@ import {
   NgZone,
   Optional,
 } from '@angular/core';
-import * as MapboxGl from 'mapbox-gl';
+import MapboxGl from 'mapbox-gl';
 import { AsyncSubject, Observable, Subscription } from 'rxjs';
 import { first } from 'rxjs/operators';
 import {


### PR DESCRIPTION
fixing es-build angular 16 build with error
```
Cannot assign to import "baseApiUrl"

    node_modules/ngx-mapbox-gl/fesm2022/ngx-mapbox-gl.mjs:34:25:
      34 │                 MapboxGl.baseApiUrl = options.customMapboxApiUrl;
         ╵                          ~~~~~~~~~~

  Imports are immutable in JavaScript. To modify the value of this import
```
related to https://github.com/evanw/esbuild/issues/891,



fixes:
https://github.com/Wykks/ngx-mapbox-gl/issues/403
https://github.com/Wykks/ngx-mapbox-gl/issues/407