### PR TITLE
fix: adjust package json angular v18

### DIFF
--- a/libs/ngx-mapbox-gl/package.json
+++ b/libs/ngx-mapbox-gl/package.json
@@ -20,12 +20,12 @@
   },
   "homepage": "https://github.com/Wykks/ngx-mapbox-gl#readme",
   "peerDependencies": {
-    "@angular/core": "^16.0.0 || ^17.0.0",
-    "@angular/common": "^16.0.0 || ^17.0.0",
+    "@angular/core": "^18.0.0",
+    "@angular/common": "^18.0.0",
     "mapbox-gl": "^2.9.0",
     "rxjs": "^7.8.0"
   },
   "dependencies": {
-    "tslib": "^2.4.0"
+    "tslib": "^2.6.0"
   }
 }


### PR DESCRIPTION
The npm package still has a depencency on Angular 16 or 17 instead of v18.
Updated the package.json to v18.
Not tested locally, so I'm not sure if other changes are still needed.