### PR TITLE
feat: add support for testMode property

### DIFF
--- a/libs/ngx-mapbox-gl/src/lib/map/map.component.ts
+++ b/libs/ngx-mapbox-gl/src/lib/map/map.component.ts
@@ -76,6 +76,7 @@ export class MapComponent implements OnChanges, OnDestroy {
   antialias = input<MapOptions['antialias']>();
   locale = input<MapOptions['locale']>();
   cooperativeGestures = input<MapOptions['cooperativeGestures']>();
+  testMode = input<MapOptions['testMode']>();
 
   /* Dynamic inputs */
   minZoom = input<MapOptions['minZoom']>();
@@ -216,6 +217,7 @@ export class MapComponent implements OnChanges, OnDestroy {
           locale: this.locale(),
           cooperativeGestures: this.cooperativeGestures(),
           projection: this.projection(),
+          testMode: this.testMode(),
         },
         mapEvents: this,
       });


### PR DESCRIPTION
For #328 

This is simply to add the property to the options of the map component, so it can be passed on to mapbox-gl.

I would write a test but for some reason the map component tests have some issue running for me (related to zonejs import).

Is this how this should be done, or are is there another way that would be more convenient for actual tests?
